### PR TITLE
Register github:ingydotnet/git-sha512=0.1.1

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.00
-updated = 1970-01-01T00:00:00
+version = 0.1.88
+updated = 2022-11-30T04:51:18
 
 [default]
 host = github
@@ -28,3 +28,13 @@ api-issue-url = $publish.api-repo-url/issues/1/comments
 method = git
 source = https://github.com/$owner/$name
 author = https://github.com/$user
+
+[package "github:ingydotnet/git-sha512"]
+title = Like 'git rev-parse' but using sha512
+version = 0.1.1
+license = MIT
+tag = bash bpan
+author = github:ingydotnet
+update = 2022-11-30T04:51:18
+commit = 6d7e69ae3072a4e19e61a50b46cf0c3cd8dea0ad
+sha512 = 45cc32fe40d83733a684fd8681bc2a4d909c359a0e756b30eeba8a65593cdf39c66b5edf0dde5c336b213f2f48d01fa05c4bcf35131baf58435adfa4dccda791


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-ingydotnet/blob/main/index.ini):

> https://github.com/ingydotnet/git-sha512/tree/0.1.1

    package: github:ingydotnet/git-sha512
    title:   Like 'git rev-parse' but using sha512
    version: 0.1.1
    license: MIT
    author:  github:ingydotnet