### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.0

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
 version = 0.1.88
-updated = 2022-11-30T04:51:18
+updated = 2022-11-30T16:08:07
 
 [default]
 host = github
@@ -30,6 +30,16 @@ api-issue-url = $plugin.publish.api-repo-url/issues/1/comments
 method = git
 source = https://github.com/$owner/$name
 author = https://github.com/$user
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = Short description of 'foo-bar-bash'
+version = 0.1.0
+license = MIT
+tag = bash bpan
+author = github:ingydotnet
+update = 2022-11-30T16:08:07
+commit = c46211642092eecd55e88f9d68e37bf98896df26
+sha512 = 9f5731d89ffafadbbbe39e9c1f4f909b1c0c3c49b205ea2d71475fc3575de21912cbadd85faddc08844e9a91540177ab1c8341ebc7f6d0c232c6cec8a59f1813
 
 [package "github:ingydotnet/git-sha512"]
 title = Like 'git rev-parse' but using sha512


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-ingydotnet/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.0

    package: github:ingydotnet/foo-bar-bash
    title:   Short description of 'foo-bar-bash'
    version: 0.1.0
    license: MIT
    author:  github:ingydotnet