### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.2

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00
+version = 0.1.92
+updated = 2022-12-06T15:21:44
 
 [default]
 host = github
@@ -8,17 +8,17 @@ owner = bpan-org
 
 [license]
 spdx = \
- Apache-2.0 \
- BSD-2-Clause \
- BSD-3-Clause \
- CDDL-1.0 \
- EPL-2.0 \
- GPL-2.0-only \
- GPL-2.0-or-later \
- GPL-3.0-only \
- GPL-3.0-or-later \
- MIT \
- MPL-2.0 \
+Apache-2.0 \
+BSD-2-Clause \
+BSD-3-Clause \
+CDDL-1.0 \
+EPL-2.0 \
+GPL-2.0-only \
+GPL-2.0-or-later \
+GPL-3.0-only \
+GPL-3.0-or-later \
+MIT \
+MPL-2.0 \
 
 [plugin "publish"]
 source = https://github.com/bpan-org/bpan-plugin-publish-gha
@@ -32,3 +32,13 @@ publish-issue-id = 1
 method = git
 source = https://github.com/$owner/$name
 author = https://github.com/$user
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = Short description of 'foo-bar-bash'
+version = 0.1.2
+license = MIT
+tag = bash bpan
+author = github:ingydotnet
+update = 2022-12-06T15:21:44
+commit = b6787c5452548605435cdd123619d91af5d458c2
+sha512 = f47d8c1d0b1b0f0ae555f3b214b3965ba43a0ddb54a850e7a6e3c8b4171b9f5b858427ad270213dcb694ee58342447e7e93dea14d78be28700d844c1e4a4f7ae


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-ingydotnet/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.2

    package: github:ingydotnet/foo-bar-bash
    title:   Short description of 'foo-bar-bash'
    version: 0.1.2
    license: MIT
    author:  github:ingydotnet