### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.2

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00
+version = 0.1.97
+updated = 2022-12-13-10-43-57
 
 [default]
 host = github
@@ -32,3 +32,13 @@ spdx = \
  GPL-3.0-or-later \
  MIT \
  MPL-2.0 \
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = short description of 'foo-bar-bash'
+version = 0.1.2
+license = MIT
+tag = bash bpan
+author = https://github.com/ingydotnet
+update = 2022-12-13-10-43-57
+commit = cd694deb315d78540f8f91a27545d5084d940796
+sha512 = 2da962a8d8f94d4080aa4fbf5237b26fe27ddcf8a24bad200ea33932396fb0f7fda59c6443eb378aa6e315ed73138ebca30e61814112608327b2dd52e2fd81ca


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-ingydotnet/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.2

    package: github:ingydotnet/foo-bar-bash
    title:   short description of 'foo-bar-bash'
    version: 0.1.2
    license: MIT
    author:  https://github.com/ingydotnet