### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.0

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00
+version = 0.1.99
+updated = 2022-12-14-17-03-42
 
 [default]
 host = github
@@ -32,3 +32,13 @@ spdx = \
  GPL-3.0-or-later \
  MIT \
  MPL-2.0 \
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = short description of 'foo-bar-bash'
+version = 0.1.0
+license = MIT
+tag = bash bpan
+author = https://github.com/ingydotnet
+update = 2022-12-14-17-03-42
+commit = dfa0f9984c7ad1e7aa4d313f1e3195abcfc0aa93
+sha512 = 76ed5f375fb6c1060f9b8dfc895bc2b834d362d8cfae31d3e46f36080d4e36a8204f27234a2ec9d010e71ba85ae9693dbe58fae631578fd2b57e9f417cfcde9f


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-ingydotnet/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.0

    package: github:ingydotnet/foo-bar-bash
    title:   short description of 'foo-bar-bash'
    version: 0.1.0
    license: MIT
    author:  https://github.com/ingydotnet