### PR TITLE
Register github:bpan-org/json-bash=0.1.2

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
 version = 0.1.107
-updated = 2023-01-01T16:12:03Z
+updated = 2023-07-14T13:26:46Z
 
 [default]
 host = github
@@ -26,6 +26,19 @@ CDDL-1.0 \
 GPL-3.0-or-later \
 MIT \
 MPL-2.0 \
+
+[package "github:bpan-org/json-bash"]
+title = JSON library for Bash
+version = 0.1.2
+license = MIT
+summary = ""
+type = bash:lib
+tag = ""
+source = https://github.com/bpan-org/json-bash/tree/0.1.2
+author = https://github.com/ingydotnet
+update = 2023-07-14T13:26:46Z
+commit = 8b047663456eeaf618b759638053cf84dceb838c
+sha512 = 902d3560ead5ffe93ac2c4d47ac4e5f99e7549ac339b2e3e1d8f9c4a7e04533d0b9f1499fc61b0480c984ed779051b1969206cddbd11e05c6e12d9a8976ea11e
 
 [package "github:ingydotnet/pst"]
 title = Package Super Tool — Package Management for All Programming Languages


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-ingydotnet/blob/main/index.ini):

> https://github.com/bpan-org/json-bash/tree/0.1.2

    package: github:bpan-org/json-bash
    title:   JSON library for Bash
    version: 0.1.2
    type:    bash:lib
    license: MIT
    author:  https://github.com/ingydotnet